### PR TITLE
chore: allow laravel 13 (testbench ^11) and cover it in CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.3, 8.4]
-        laravel: [11.*, 12.*]
+        laravel: [11.*, 12.*, 13.*]
         filament: [5.*]
         stability: [prefer-stable]
         include:
@@ -22,6 +22,9 @@ jobs:
             filament: 5.*
           - laravel: 12.*
             testbench: 10.*
+            filament: 5.*
+          - laravel: 13.*
+            testbench: 11.*
             filament: 5.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }}

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.72",
         "nunomaduro/collision": "^8.0",
-        "orchestra/testbench": "^9.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
         "pestphp/pest": "^4.0",
         "pestphp/pest-plugin-arch": "^4.0",
         "pestphp/pest-plugin-laravel": "^4.0",


### PR DESCRIPTION
Part of the Laravel 13 readiness sweep across visualbuilder packages (neurobox NB-2860 groundwork).

Constraint widening only — no behaviour changes. Suite verified locally on laravel/framework **v13.19.0**: 38 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)